### PR TITLE
feat: pass options to react-player

### DIFF
--- a/src/ReactEmbed.tsx
+++ b/src/ReactEmbed.tsx
@@ -15,6 +15,7 @@ export interface ParsedUrl {
 export type EmbedBlockId = string;
 export interface BlockProps extends ParsedUrl {
   id: EmbedBlockId;
+  options?: object | undefined;
   renderVoid: (error?: Error) => React.ReactElement<any> | null;
   renderWrap: ReactEmbedWrapRenderer;
 }
@@ -58,6 +59,7 @@ const renderWrap = (children) => children;
 
 export interface ReactEmbedProps {
   url: string;
+  options?: object | undefined;
   blocks?: Blocks;
   router?: ReactEmbedRouter;
   render?: ReactEmbedRenderer;

--- a/src/ReactEmbed.tsx
+++ b/src/ReactEmbed.tsx
@@ -15,7 +15,7 @@ export interface ParsedUrl {
 export type EmbedBlockId = string;
 export interface BlockProps extends ParsedUrl {
   id: EmbedBlockId;
-  options?: object | undefined;
+  options?: object;
   renderVoid: (error?: Error) => React.ReactElement<any> | null;
   renderWrap: ReactEmbedWrapRenderer;
 }
@@ -59,7 +59,7 @@ const renderWrap = (children) => children;
 
 export interface ReactEmbedProps {
   url: string;
-  options?: object | undefined;
+  options?: object;
   blocks?: Blocks;
   router?: ReactEmbedRouter;
   render?: ReactEmbedRenderer;

--- a/src/blocks/react-player/index.tsx
+++ b/src/blocks/react-player/index.tsx
@@ -6,8 +6,8 @@ const style = {
   maxWidth: '100%',
 };
 
-const ReactPlayerWrapper: React.SFC<BlockProps> = ({url, renderWrap}) => {
-  return renderWrap(<ReactPlayer url={url} style={style} />);
+const ReactPlayerWrapper: React.SFC<BlockProps> = ({url, renderWrap, options}) => {
+  return renderWrap(<ReactPlayer {...options} url={url} style={style} />);
 };
 
 export default ReactPlayerWrapper;

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -4,7 +4,9 @@ import {ReactEmbedRenderer} from '.';
 const renderer: ReactEmbedRenderer = (Block: any, id, props, state) => {
   const renderVoid = (error) => props.renderVoid!(props, state, error);
 
-  return <Block {...state.url} id={id} renderWrap={props.renderWrap!} renderVoid={renderVoid} />;
+  return (
+    <Block {...state.url} options={props.options} id={id} renderWrap={props.renderWrap!} renderVoid={renderVoid} />
+  );
 };
 
 export default renderer;


### PR DESCRIPTION
Allow passing options to embeds using React Player, effectively allowing users to play a video :-)

Example:
```jsx
<Embed url={'https://vimeo.com/54763818'} options={{ controls: true }} />
```